### PR TITLE
Fix bug in the calcluation of totalRelevantRecords

### DIFF
--- a/src/Filter_Merge_Calculate_Function.R
+++ b/src/Filter_Merge_Calculate_Function.R
@@ -68,10 +68,13 @@ filter_merge_calculate_function <- function(gtFileLocation, outputFileLocation){
     ##
     #n <- "q2"
    
-    #Count the total number of Relevant dataset for a specific query from the ground truth
-    queryOfInterest <- which( colnames(filtered_merged_result) == n )
-    counter <- table(filtered_merged_result[queryOfInterest])
-    totalRelevantRecords <- counter[names(counter)==1]
+    # Count the total number of Relevant dataset for a specific query from the ground truth
+      
+    # First, get just the unique comnbinations of Dataset_ID and the value in 
+    # column 'n' (e.g. q1, q2, etc) so we don't count 
+    unique_query_result <- unique(filtered_merged_result[,c("Dataset_ID", n)])
+    counter <- table(unique_query_result[,n])
+    totalRelevantRecords <- counter[names(counter) == 1]
 
     for (j in solrtypecolumns) {
       


### PR DESCRIPTION
This bug was causing recall values to be much lower than expected
and was caused by duplicated values of Dataset_ID being present
in the data.frame 'filtered_merged_result' prior to the calculation
of totalRelevantRecords. This change filters filtered_merged_result
prior to the calculation to just the unique combinations of
Dataset_ID and whatever query we're looking at (q1, q2, etc).
